### PR TITLE
Update sodiumoxide to 0.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ reqwest = "0.8"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-sodiumoxide = "0.0.16"
+sodiumoxide = "0.1.0"
 
 [dev-dependencies]
 docopt = "0.8"


### PR DESCRIPTION
Updates sodiumoxide to [0.1](https://github.com/sodiumoxide/sodiumoxide/releases/tag/0.1.0). Right now I don't see any breaking changes, but if I find any will push it in the same PR. 