### PR TITLE
Pin docopt to 1.0.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,5 +33,5 @@ serde_json = "1.0"
 sodiumoxide = "0.2.0"
 
 [dev-dependencies]
-docopt = "1.0"
+docopt = "~1.0"
 mime_guess = "2.0.0-alpha.6"


### PR DESCRIPTION
Version 1.1 does not build on Rust 1.31 anymore.