### PR TITLE
Allow adding file message metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Possible log types:
 ### Unreleased
 
 - [added] Allow specifying `RenderingType` for file messages
+- [added] Allow specifying media metadata for file messages
 - [changed] The API for `E2eApi::encrypt_file_msg` has changed
 - [changed] You now need to import `std::str::FromStr` to directly access
   `BlobId::from_str` or `RecipientKey::from_str`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ Possible log types:
 ### Unreleased
 
 - [added] Allow specifying `RenderingType` for file messages
-- [changed] You now need to import `std::str::FromStr` to access
+- [changed] The API for `E2eApi::encrypt_file_msg` has changed
+- [changed] You now need to import `std::str::FromStr` to directly access
   `BlobId::from_str` or `RecipientKey::from_str`
 
 ### v0.12.1 (2019-10-22)

--- a/examples/send_e2e_file.rs
+++ b/examples/send_e2e_file.rs
@@ -113,7 +113,8 @@ fn main() {
         .file_name_opt(file_name)
         .description("File message description")
         .rendering_type(RenderingType::File)
-        .build();
+        .build()
+        .expect("Could not build FileMessage");
     let encrypted = api.encrypt_file_msg(&msg, &recipient_key);
 
     // Send

--- a/src/api.rs
+++ b/src/api.rs
@@ -9,9 +9,9 @@ use crate::crypto::{EncryptedMessage, RecipientKey};
 use crate::errors::{ApiBuilderError, ApiError};
 use crate::lookup::{lookup_capabilities, lookup_credits, lookup_id, lookup_pubkey};
 use crate::lookup::{Capabilities, LookupCriterion};
-use crate::types::{BlobId, MessageType, RenderingType};
+use crate::types::{BlobId, FileMessage, MessageType};
+use crate::SecretKey;
 use crate::MSGAPI_URL;
-use crate::{Key, Mime, SecretKey};
 
 /// Implement methods available on both the simple and the e2e API objects.
 macro_rules! impl_common_functionality {
@@ -159,39 +159,16 @@ impl E2eApi {
 
     /// Encrypt a file message for the specified recipient public key.
     ///
-    /// Before calling this function, you need to symetrically encrypt the file
-    /// data (libsodium secretbox, random key) and upload the ciphertext to the
-    /// blob server. If you also want to set a thumbnail, do the same with the
-    /// update data (in JPEG format) and use the same key. Use the nonce
-    /// `000...1` for the file and `000...2` for the thumbnail.
+    /// To construct a [`FileMessage`], use [`FileMessageBuilder`].
     ///
-    /// The file size needs to be specified in bytes. Note that the size is
-    /// only used for download size displaying purposes and has no security
-    /// implications.
+    /// [`FileMessage`]: struct.FileMessage.html
+    /// [`FileMessageBuilder`]: struct.FileMessageBuilder.html
     pub fn encrypt_file_msg(
         &self,
-        file_blob_id: &BlobId,
-        thumbnail_blob_id: Option<&BlobId>,
-        blob_encryption_key: &Key,
-        mime_type: &Mime,
-        file_name: Option<&str>,
-        file_size_bytes: u32,
-        description: Option<&str>,
-        rendering_type: RenderingType,
+        msg: &FileMessage,
         recipient_key: &RecipientKey,
     ) -> EncryptedMessage {
-        encrypt_file_msg(
-            file_blob_id,
-            thumbnail_blob_id,
-            blob_encryption_key,
-            mime_type,
-            file_name,
-            file_size_bytes,
-            description,
-            rendering_type,
-            &recipient_key.0,
-            &self.private_key,
-        )
+        encrypt_file_msg(msg, &recipient_key.0, &self.private_key)
     }
 
     /// Send an encrypted E2E message to the specified Threema ID.

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -4,7 +4,6 @@ use std::convert::Into;
 use std::io::Write;
 use std::iter::repeat;
 use std::str::FromStr;
-use std::string::ToString;
 
 use byteorder::{LittleEndian, WriteBytesExt};
 use data_encoding::{HEXLOWER, HEXLOWER_PERMISSIVE};
@@ -13,8 +12,8 @@ use sodiumoxide::crypto::box_;
 use sodiumoxide::randombytes::randombytes_into;
 
 use crate::errors::CryptoError;
-use crate::types::{BlobId, FileMessage, MessageType, RenderingType};
-use crate::{Key, Mime, PublicKey, SecretKey};
+use crate::types::{BlobId, FileMessage, MessageType};
+use crate::{PublicKey, SecretKey};
 
 /// Return a random number in the range `[1, 255]`.
 fn random_padding_amount() -> u8 {
@@ -145,28 +144,11 @@ pub fn encrypt_image_msg(
 
 /// Encrypt a file message for the recipient.
 pub fn encrypt_file_msg(
-    file_blob_id: &BlobId,
-    thumbnail_blob_id: Option<&BlobId>,
-    blob_encryption_key: &Key,
-    mime_type: &Mime,
-    file_name: Option<&str>,
-    file_size_bytes: u32,
-    description: Option<&str>,
-    rendering_type: RenderingType,
+    msg: &FileMessage,
     public_key: &PublicKey,
     private_key: &SecretKey,
 ) -> EncryptedMessage {
-    let msg = FileMessage::new(
-        file_blob_id.clone(),
-        thumbnail_blob_id.cloned(),
-        blob_encryption_key.clone(),
-        mime_type.clone(),
-        file_name.map(ToString::to_string),
-        file_size_bytes,
-        description.map(ToString::to_string),
-        rendering_type,
-    );
-    let data = json::to_string(&msg).unwrap();
+    let data = json::to_string(msg).unwrap();
     let msgtype = MessageType::File;
     encrypt(&data.as_bytes(), msgtype, &public_key, &private_key)
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -72,12 +72,23 @@ quick_error! {
 }
 
 quick_error! {
-    /// Errors when interacting with the [`ApiBuilder`](struct.ApiBuilder.html).
+    /// Errors when interacting with the [`ApiBuilder`](../struct.ApiBuilder.html).
     #[derive(Debug)]
     pub enum ApiBuilderError {
         /// No private key has been set.
         MissingKey {}
         /// Invalid libsodium private key.
         InvalidKey(msg: String) {}
+    }
+}
+
+quick_error! {
+    /// Errors when interacting with the [`FileMessageBuilder`](../struct.FileMessageBuilder.html).
+    #[derive(Debug)]
+    pub enum FileMessageBuilderError {
+        /// Illegal combination of fields (e.g. setting the `animated` flag on a PDF file message).
+        IllegalCombination(msg: &'static str) {
+            display("IllegalCombination: {}", msg)
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@ pub use crate::api::{ApiBuilder, E2eApi, SimpleApi};
 pub use crate::connection::Recipient;
 pub use crate::crypto::{EncryptedMessage, RecipientKey};
 pub use crate::lookup::{Capabilities, LookupCriterion};
-pub use crate::types::{BlobId, MessageType, RenderingType};
+pub use crate::types::{BlobId, FileMessage, FileMessageBuilder, MessageType, RenderingType};
 
 const MSGAPI_URL: &str = "https://msgapi.threema.ch";
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -69,56 +69,168 @@ impl Default for RenderingType {
 #[derive(Debug, Serialize)]
 pub struct FileMessage {
     #[serde(rename = "b")]
-    pub file_blob_id: BlobId,
+    pub(crate) file_blob_id: BlobId,
     #[serde(rename = "t")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub thumbnail_blob_id: Option<BlobId>,
+    pub(crate) thumbnail_blob_id: Option<BlobId>,
     #[serde(rename = "k")]
     #[serde(serialize_with = "key_to_hex")]
-    pub blob_encryption_key: Key,
+    pub(crate) blob_encryption_key: Key,
     #[serde(rename = "m")]
     #[serde(serialize_with = "serialize_to_string")]
-    pub mime_type: Mime,
+    pub(crate) mime_type: Mime,
     #[serde(rename = "n")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub file_name: Option<String>,
+    pub(crate) file_name: Option<String>,
     #[serde(rename = "s")]
-    pub file_size_bytes: u32,
+    pub(crate) file_size_bytes: u32,
     #[serde(rename = "d")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
+    pub(crate) description: Option<String>,
     #[serde(rename = "j")]
-    pub rendering_type: RenderingType,
+    pub(crate) rendering_type: RenderingType,
     #[serde(rename = "i")]
-    pub reserved: u8,
+    pub(crate) reserved: u8,
 }
 
 impl FileMessage {
-    /// Create a new file message.
-    pub fn new(
+    /// Shortcut for [`FileMessageBuilder::new`](struct.FileMessageBuilder.html#method.new).
+    pub fn builder(
         file_blob_id: BlobId,
-        thumbnail_blob_id: Option<BlobId>,
         blob_encryption_key: Key,
         mime_type: Mime,
-        file_name: Option<String>,
         file_size_bytes: u32,
-        description: Option<String>,
-        rendering_type: RenderingType,
-    ) -> Self {
-        FileMessage {
+    ) -> FileMessageBuilder {
+        FileMessageBuilder::new(
             file_blob_id,
-            thumbnail_blob_id,
             blob_encryption_key,
             mime_type,
-            file_name,
             file_size_bytes,
-            description,
-            rendering_type,
-            reserved: match rendering_type {
-                RenderingType::File => 0,
-                RenderingType::Media => 1,
-                RenderingType::Sticker => 1,
-            },
+        )
+    }
+}
+
+/// Builder for [`FileMessage`](struct.FileMessage.html).
+pub struct FileMessageBuilder {
+    file_blob_id: BlobId,
+    thumbnail_blob_id: Option<BlobId>,
+    blob_encryption_key: Key,
+    mime_type: Mime,
+    file_name: Option<String>,
+    file_size_bytes: u32,
+    description: Option<String>,
+    rendering_type: RenderingType,
+    reserved: u8,
+}
+
+impl FileMessageBuilder {
+    /// Create a new [`FileMessage`] builder.
+    ///
+    /// Before calling this function, you need to symmetrically encrypt the file
+    /// data (libsodium secretbox, random key) and upload the ciphertext to the
+    /// blob server. Use the nonce `000...1` to encrypt the file data.
+    ///
+    /// The `file_blob_id` must point to the blob id of the uploaded file data,
+    /// encrypted with `blob_encryption_key`.
+    ///
+    /// The file size needs to be specified in bytes. Note that the size is
+    /// only used for download size displaying purposes and has no security
+    /// implications.
+    ///
+    /// [`FileMessage`]: struct.FileMessage.html
+    pub fn new(
+        file_blob_id: BlobId,
+        blob_encryption_key: Key,
+        mime_type: Mime,
+        file_size_bytes: u32,
+    ) -> Self {
+        FileMessageBuilder {
+            file_blob_id,
+            thumbnail_blob_id: None,
+            blob_encryption_key,
+            mime_type,
+            file_name: None,
+            file_size_bytes,
+            description: None,
+            rendering_type: RenderingType::File,
+            reserved: 0,
+        }
+    }
+
+    /// Set a thumbnail.
+    ///
+    /// Before calling this function, you need to symmetrically encrypt the
+    /// thumbnail data (in JPEG format) with the same key used for the file
+    /// data and with the nonce `000...2`.
+    pub fn thumbnail(self, blob_id: BlobId) -> Self {
+        self.thumbnail_opt(Some(blob_id))
+    }
+
+    /// Set a thumbnail from an Option.
+    ///
+    /// Before calling this function, you need to symmetrically encrypt the
+    /// thumbnail data (in JPEG format) with the same key used for the file
+    /// data and with the nonce `000...2`.
+    pub fn thumbnail_opt(mut self, blob_id: Option<BlobId>) -> Self {
+        self.thumbnail_blob_id = blob_id;
+        self
+    }
+
+    /// Set the file name.
+    ///
+    /// Note that the file name will not be shown in the clients if the
+    /// rendering type is not set to `File`.
+    pub fn file_name(self, file_name: impl Into<String>) -> Self {
+        self.file_name_opt(Some(file_name))
+    }
+
+    /// Set the file name from an Option.
+    ///
+    /// Note that the file name will not be shown in the clients if the
+    /// rendering type is not set to `File`.
+    pub fn file_name_opt(mut self, file_name: Option<impl Into<String>>) -> Self {
+        self.file_name = file_name.map(Into::into);
+        self
+    }
+
+    /// Set the file description / caption.
+    pub fn description(self, description: impl Into<String>) -> Self {
+        self.description_opt(Some(description))
+    }
+
+    /// Set the file description / caption from an Option.
+    pub fn description_opt(mut self, description: Option<impl Into<String>>) -> Self {
+        self.description = description.map(Into::into);
+        self
+    }
+
+    /// Set the rendering type.
+    ///
+    /// See [`RenderingType`](enum.RenderingType.html) docs for more information.
+    pub fn rendering_type(mut self, rendering_type: RenderingType) -> Self {
+        self.rendering_type = rendering_type;
+        self.reserved = match rendering_type {
+            RenderingType::File => 0,
+            RenderingType::Media => 1,
+            RenderingType::Sticker => 1,
+        };
+        self
+    }
+
+    /// Create a [`FileMessage`] from this builder.
+    ///
+    /// [`FileMessage`]: struct.FileMessage.html
+    pub fn build(self) -> FileMessage {
+        FileMessage {
+            file_blob_id: self.file_blob_id,
+            thumbnail_blob_id: self.thumbnail_blob_id,
+            blob_encryption_key: self.blob_encryption_key,
+            mime_type: self.mime_type,
+            file_name: self.file_name,
+            file_size_bytes: self.file_size_bytes,
+            description: self.description,
+            rendering_type: self.rendering_type,
+            reserved: self.reserved,
         }
     }
 }
@@ -203,16 +315,17 @@ mod test {
             1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1,
             2, 3, 4,
         ]);
-        let msg = FileMessage::new(
-            BlobId::from_str("0123456789abcdef0123456789abcdef").unwrap(),
-            None,
-            pk,
-            "application/pdf".parse().unwrap(),
-            None,
-            2048,
-            None,
-            RenderingType::File,
-        );
+        let msg = FileMessage {
+            file_blob_id: BlobId::from_str("0123456789abcdef0123456789abcdef").unwrap(),
+            thumbnail_blob_id: None,
+            blob_encryption_key: pk,
+            mime_type: "application/pdf".parse().unwrap(),
+            file_name: None,
+            file_size_bytes: 2048,
+            description: None,
+            rendering_type: RenderingType::File,
+            reserved: 0,
+        };
         let data = json::to_string(&msg).unwrap();
         let deserialized: HashMap<String, json::Value> = json::from_str(&data).unwrap();
 
@@ -240,16 +353,17 @@ mod test {
             1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1,
             2, 3, 4,
         ]);
-        let msg = FileMessage::new(
-            BlobId::from_str("0123456789abcdef0123456789abcdef").unwrap(),
-            Some(BlobId::from_str("abcdef0123456789abcdef0123456789").unwrap()),
-            pk,
-            "application/pdf".parse().unwrap(),
-            Some("secret.pdf".into()),
-            2048,
-            Some("This is a fancy file".into()),
-            RenderingType::Sticker,
-        );
+        let msg = FileMessage {
+            file_blob_id: BlobId::from_str("0123456789abcdef0123456789abcdef").unwrap(),
+            thumbnail_blob_id: Some(BlobId::from_str("abcdef0123456789abcdef0123456789").unwrap()),
+            blob_encryption_key: pk,
+            mime_type: "application/pdf".parse().unwrap(),
+            file_name: Some("secret.pdf".into()),
+            file_size_bytes: 2048,
+            description: Some("This is a fancy file".into()),
+            rendering_type: RenderingType::Sticker,
+            reserved: 1,
+        };
         let data = json::to_string(&msg).unwrap();
         let deserialized: HashMap<String, json::Value> = json::from_str(&data).unwrap();
 
@@ -272,5 +386,32 @@ mod test {
         assert_eq!(deserialized.get("j").unwrap(), 2);
         assert_eq!(deserialized.get("i").unwrap(), 1);
         assert_eq!(deserialized.get("d").unwrap(), "This is a fancy file");
+    }
+
+    #[test]
+    fn test_builder() {
+        let key = Key([
+            1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1,
+            2, 3, 4,
+        ]);
+        let file_blob_id = BlobId::from_str("0123456789abcdef0123456789abcdef").unwrap();
+        let thumb_blob_id = BlobId::from_str("abcdef0123456789abcdef0123456789").unwrap();
+        let mime_type: Mime = "image/jpeg".parse().unwrap();
+        let msg = FileMessage::builder(file_blob_id.clone(), key.clone(), mime_type.clone(), 2048)
+            .thumbnail(thumb_blob_id.clone())
+            .file_name("hello.jpg")
+            .description(String::from("An image file"))
+            .rendering_type(RenderingType::Media)
+            .build();
+
+        assert_eq!(msg.file_blob_id, file_blob_id);
+        assert_eq!(msg.thumbnail_blob_id, Some(thumb_blob_id));
+        assert_eq!(msg.blob_encryption_key, key);
+        assert_eq!(msg.mime_type, mime_type);
+        assert_eq!(msg.file_name, Some("hello.jpg".to_string()));
+        assert_eq!(msg.file_size_bytes, 2048);
+        assert_eq!(msg.description, Some("An image file".to_string()));
+        assert_eq!(msg.rendering_type, RenderingType::Media);
+        assert_eq!(msg.reserved, 1);
     }
 }


### PR DESCRIPTION
The E2eApi::encrypt_file_msg API has changed and now accepts a `FileMessage`, which should be constructed through `FileMessageBuilder`.