### PR TITLE
Create encrypt_file_data helper function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Possible log types:
 - `[security]` to invite users to upgrade in case of vulnerabilities.
 
 
+### Unreleased
+
+- [added] New helper function `encrypt_file_data` for encrypting the data and
+  thumbnail that is sent inside a file message (#?)
+
 ### v0.14.0 (2021-03-27)
 
 This release changes the entire API from blocking to async. This makes it much

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,7 @@ pub use sodiumoxide::crypto::secretbox::Key;
 
 pub use crate::api::{ApiBuilder, E2eApi, SimpleApi};
 pub use crate::connection::Recipient;
-pub use crate::crypto::{EncryptedMessage, RecipientKey};
+pub use crate::crypto::{encrypt_file_data, EncryptedMessage, RecipientKey};
 pub use crate::lookup::{Capabilities, LookupCriterion};
 pub use crate::types::{BlobId, FileMessage, FileMessageBuilder, MessageType, RenderingType};
 


### PR DESCRIPTION
Fixes #47.

This way, the users of the library don't have to use raw sodiumoxide calls.