### PR TITLE
MessageType: Add Other(u8) variant as escape hatch

### DIFF
--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -97,7 +97,7 @@ pub fn encrypt_raw(
     }
 }
 
-/// Encrypt a message for the recipient.
+/// Encrypt a message with the specified `msgtype` for the recipient.
 ///
 /// The encrypted data will include PKCS#7 style random padding.
 pub fn encrypt(

--- a/src/types.rs
+++ b/src/types.rs
@@ -11,11 +11,18 @@ use crate::{
 /// A message type.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum MessageType {
+    /// Text message
     Text,
+    /// Image message (deprecated)
     Image,
+    /// Video message (deprecated)
     Video,
+    /// File message
     File,
+    /// Delivery receipt
     DeliveryReceipt,
+    /// Another message type
+    Other(u8),
 }
 
 impl From<MessageType> for u8 {
@@ -26,6 +33,7 @@ impl From<MessageType> for u8 {
             MessageType::Video => 0x13,
             MessageType::File => 0x17,
             MessageType::DeliveryReceipt => 0x80,
+            MessageType::Other(msgtype_byte) => msgtype_byte,
         }
     }
 }


### PR DESCRIPTION
This allows encrypting arbitrary message types.