### PR TITLE
Remove mime dependency in favor of plain strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Possible log types:
 
 ### Unreleased
 
-...
+- [changed] Remove `mime` dependency in favor of plain strings (#64)
 
 ### v0.15.1 (2021-12-06)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ byteorder = "1.0"
 data-encoding = "2.1"
 form_urlencoded = { version = "1", optional = true }
 log = "0.4"
-mime = "0.3"
 thiserror = "1"
 reqwest = { version = "0.11", features = ["rustls-tls-native-roots", "multipart"], default-features = false }
 serde = { version = "1.0", features = ["derive"] }

--- a/examples/send_e2e_file.rs
+++ b/examples/send_e2e_file.rs
@@ -102,15 +102,18 @@ async fn main() {
             api.blob_upload_raw(&et, false).await,
             "Could not upload thumbnail to blob server"
         );
-        let thumbnail_media_type =
-            mime_guess::from_path(&thumbpath.unwrap()).first_or_octet_stream();
+        let thumbnail_media_type = mime_guess::from_path(thumbpath.unwrap())
+            .first_or_octet_stream()
+            .to_string();
         Some((blob_id, thumbnail_media_type))
     } else {
         None
     };
 
     // Create file message
-    let file_media_type = mime_guess::from_path(&filepath).first_or_octet_stream();
+    let file_media_type = mime_guess::from_path(filepath)
+        .first_or_octet_stream()
+        .to_string();
     let file_name = filepath.file_name().and_then(OsStr::to_str);
     let msg = FileMessage::builder(file_blob_id, key, file_media_type, file_data.len() as u32)
         .thumbnail_opt(thumb_blob_id)
@@ -122,7 +125,7 @@ async fn main() {
     let encrypted = api.encrypt_file_msg(&msg, &public_key.into());
 
     // Send
-    let msg_id = api.send(&to, &encrypted, false).await;
+    let msg_id = api.send(to, &encrypted, false).await;
     match msg_id {
         Ok(id) => println!("Sent. Message id is {}.", id),
         Err(e) => println!("Could not send message: {}", e),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,6 @@ mod lookup;
 mod receive;
 mod types;
 
-pub use mime::Mime;
 pub use sodiumoxide::crypto::{
     box_::{PublicKey, SecretKey},
     secretbox::Key,


### PR DESCRIPTION
The mime library is not actively maintained anymore: https://github.com/hyperium/mime/issues/135

We could have switched to the mediatype library, but since it would be part of the public API (and it isn't 1.0 yet), it's an unnecessary maintenance burden for little to no gain.