### PR TITLE
Enable default features for reqwest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ data-encoding = "2.1"
 form_urlencoded = { version = "1", optional = true }
 hmac = "0.12.1"
 log = "0.4"
-reqwest = { version = "0.13", features = ["multipart", "json", "query", "form"], default-features = false }
+reqwest = { version = "0.13", features = ["multipart", "json", "query", "form"] }
 rand = "0.9"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
Otherwise TLS support gets disabled.

(Follow-up for #92)