### PR TITLE
Add optional sqlx support for newtypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Possible log types:
 - `[fixed]` for any bug fixes.
 - `[security]` to invite users to upgrade in case of vulnerabilities.
 
+### Unreleased
+
+- [added] Optional [sqlx](https://docs.rs/sqlx/) support for the following
+  newtypes: `ThreemaId`, `MessageId`, `BlobId`, `RecipientKey`
+
 ### v0.21.0 (2026-06-02)
 
 This release contains a small breaking change in the `IncomingMessage` type:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ default = ["receive"]
 receive = ["form_urlencoded", "serde_urlencoded"] # Support for receiving and decrypting incoming messages
 public-key-cache-inmemory = ["moka"] # In-memory cache backed by moka
 public-key-cache-redis = ["redis"] # Redis-backed cache
+sqlx = ["dep:sqlx"] # `sqlx::Type`/`Encode`/`Decode` impls for newtypes (database-generic)
 
 [dependencies]
 byteorder = "1.0"
@@ -46,6 +47,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_urlencoded = { version = "0.7", optional = true }
 sha2 = "0.11"
+sqlx = { version = "0.8", optional = true, default-features = false }
 thiserror = "2"
 url = "2.5.4"
 zeroize = { version = "1", features = ["zeroize_derive"], default-features = false }
@@ -57,6 +59,7 @@ imagesize = "0.14"
 insta = { version = "1", features = ["json"] }
 mime_guess = "2.0.0"
 rstest = "0.26"
+sqlx = { version = "0.8", default-features = false, features = ["sqlite"] }
 tokio = { version = "1", features = ["macros", "net", "rt"], default-features = false }
 tokio-test = "0.4"
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ This library offers the following optional features:
 - `public-key-cache-inmemory`: Add support for `InMemoryPublicKeyCache` implementation backed by
   [moka](https://crates.io/crates/moka).
 - `public-key-cache-redis`: Add support for `RedisPublicKeyCache` implementation.
+- `sqlx`: Provide database-generic [`sqlx`](https://crates.io/crates/sqlx) `Type`, `Encode`, and
+  `Decode` impls for the following newtypes: `ThreemaId`, `MessageId`, `BlobId`, `RecipientKey`.
 
 ## Rust Version Requirements (MSRV)
 

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -188,6 +188,49 @@ impl FromStr for RecipientKey {
     }
 }
 
+#[cfg(feature = "sqlx")]
+impl<DB> sqlx::Type<DB> for RecipientKey
+where
+    DB: sqlx::Database,
+    Vec<u8>: sqlx::Type<DB>,
+{
+    fn type_info() -> <DB as sqlx::Database>::TypeInfo {
+        <Vec<u8> as sqlx::Type<DB>>::type_info()
+    }
+
+    fn compatible(ty: &<DB as sqlx::Database>::TypeInfo) -> bool {
+        <Vec<u8> as sqlx::Type<DB>>::compatible(ty)
+    }
+}
+
+#[cfg(feature = "sqlx")]
+impl<'enc, DB> sqlx::Encode<'enc, DB> for RecipientKey
+where
+    DB: sqlx::Database,
+    Vec<u8>: sqlx::Encode<'enc, DB>,
+{
+    fn encode_by_ref(
+        &self,
+        buf: &mut <DB as sqlx::Database>::ArgumentBuffer<'enc>,
+    ) -> Result<sqlx::encode::IsNull, sqlx::error::BoxDynError> {
+        <Vec<u8> as sqlx::Encode<'enc, DB>>::encode(self.as_bytes().to_vec(), buf)
+    }
+}
+
+#[cfg(feature = "sqlx")]
+impl<'dec, DB> sqlx::Decode<'dec, DB> for RecipientKey
+where
+    DB: sqlx::Database,
+    Vec<u8>: sqlx::Decode<'dec, DB>,
+{
+    fn decode(
+        value: <DB as sqlx::Database>::ValueRef<'dec>,
+    ) -> Result<Self, sqlx::error::BoxDynError> {
+        let bytes = <Vec<u8> as sqlx::Decode<'dec, DB>>::decode(value)?;
+        RecipientKey::from_bytes(&bytes).map_err(Into::into)
+    }
+}
+
 /// Encrypt raw data for the recipient.
 pub fn encrypt_raw(
     data: &[u8],
@@ -678,6 +721,21 @@ mod test {
                 matches!(result, Err(CryptoError::BadKey(_))),
                 "expected BadKey error for wrong-size key, got {result:?}"
             );
+        }
+    }
+
+    #[cfg(feature = "sqlx")]
+    mod sqlx_bounds {
+        use super::RecipientKey;
+
+        #[test]
+        fn implements_sqlx_traits() {
+            fn assert_type<T: sqlx::Type<sqlx::Sqlite>>() {}
+            fn assert_encode<T: for<'enc> sqlx::Encode<'enc, sqlx::Sqlite>>() {}
+            fn assert_decode<T: for<'dec> sqlx::Decode<'dec, sqlx::Sqlite>>() {}
+            assert_type::<RecipientKey>();
+            assert_encode::<RecipientKey>();
+            assert_decode::<RecipientKey>();
         }
     }
 }

--- a/src/protocol/message_id.rs
+++ b/src/protocol/message_id.rs
@@ -89,6 +89,49 @@ impl<'de> Deserialize<'de> for MessageId {
     }
 }
 
+#[cfg(feature = "sqlx")]
+impl<DB> sqlx::Type<DB> for MessageId
+where
+    DB: sqlx::Database,
+    String: sqlx::Type<DB>,
+{
+    fn type_info() -> <DB as sqlx::Database>::TypeInfo {
+        <String as sqlx::Type<DB>>::type_info()
+    }
+
+    fn compatible(ty: &<DB as sqlx::Database>::TypeInfo) -> bool {
+        <String as sqlx::Type<DB>>::compatible(ty)
+    }
+}
+
+#[cfg(feature = "sqlx")]
+impl<'enc, DB> sqlx::Encode<'enc, DB> for MessageId
+where
+    DB: sqlx::Database,
+    String: sqlx::Encode<'enc, DB>,
+{
+    fn encode_by_ref(
+        &self,
+        buf: &mut <DB as sqlx::Database>::ArgumentBuffer<'enc>,
+    ) -> Result<sqlx::encode::IsNull, sqlx::error::BoxDynError> {
+        <String as sqlx::Encode<'enc, DB>>::encode(self.to_hex_le(), buf)
+    }
+}
+
+#[cfg(feature = "sqlx")]
+impl<'dec, DB> sqlx::Decode<'dec, DB> for MessageId
+where
+    DB: sqlx::Database,
+    String: sqlx::Decode<'dec, DB>,
+{
+    fn decode(
+        value: <DB as sqlx::Database>::ValueRef<'dec>,
+    ) -> Result<Self, sqlx::error::BoxDynError> {
+        let hex = <String as sqlx::Decode<'dec, DB>>::decode(value)?;
+        MessageId::from_hex_le(&hex).map_err(Into::into)
+    }
+}
+
 /// A non-empty collection of [`MessageId`]s.
 ///
 /// This newtype guarantees at construction time that at least one message ID is
@@ -343,6 +386,21 @@ mod tests {
                 MessageIds::from_slice(&[mid(5), mid(6)]).expect("non-empty slice should succeed");
             let vec: Vec<MessageId> = ids.into();
             assert_eq!(vec, vec![mid(5), mid(6)]);
+        }
+    }
+
+    #[cfg(feature = "sqlx")]
+    mod sqlx_bounds {
+        use super::MessageId;
+
+        #[test]
+        fn implements_sqlx_traits() {
+            fn assert_type<T: sqlx::Type<sqlx::Sqlite>>() {}
+            fn assert_encode<T: for<'enc> sqlx::Encode<'enc, sqlx::Sqlite>>() {}
+            fn assert_decode<T: for<'dec> sqlx::Decode<'dec, sqlx::Sqlite>>() {}
+            assert_type::<MessageId>();
+            assert_encode::<MessageId>();
+            assert_decode::<MessageId>();
         }
     }
 }

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -58,6 +58,52 @@ impl<'de> Deserialize<'de> for BlobId {
     }
 }
 
+#[cfg(feature = "sqlx")]
+impl<DB> sqlx::Type<DB> for BlobId
+where
+    DB: sqlx::Database,
+    Vec<u8>: sqlx::Type<DB>,
+{
+    fn type_info() -> <DB as sqlx::Database>::TypeInfo {
+        <Vec<u8> as sqlx::Type<DB>>::type_info()
+    }
+
+    fn compatible(ty: &<DB as sqlx::Database>::TypeInfo) -> bool {
+        <Vec<u8> as sqlx::Type<DB>>::compatible(ty)
+    }
+}
+
+#[cfg(feature = "sqlx")]
+impl<'enc, DB> sqlx::Encode<'enc, DB> for BlobId
+where
+    DB: sqlx::Database,
+    Vec<u8>: sqlx::Encode<'enc, DB>,
+{
+    fn encode_by_ref(
+        &self,
+        buf: &mut <DB as sqlx::Database>::ArgumentBuffer<'enc>,
+    ) -> Result<sqlx::encode::IsNull, sqlx::error::BoxDynError> {
+        <Vec<u8> as sqlx::Encode<'enc, DB>>::encode(self.0.to_vec(), buf)
+    }
+}
+
+#[cfg(feature = "sqlx")]
+impl<'dec, DB> sqlx::Decode<'dec, DB> for BlobId
+where
+    DB: sqlx::Database,
+    Vec<u8>: sqlx::Decode<'dec, DB>,
+{
+    fn decode(
+        value: <DB as sqlx::Database>::ValueRef<'dec>,
+    ) -> Result<Self, sqlx::error::BoxDynError> {
+        let bytes = <Vec<u8> as sqlx::Decode<'dec, DB>>::decode(value)?;
+        let arr: [u8; 16] = bytes
+            .try_into()
+            .map_err(|bytes: Vec<u8>| format!("BlobId requires 16 bytes, got {}", bytes.len()))?;
+        Ok(BlobId::new(arr))
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -88,6 +134,21 @@ mod test {
 
             let deserialized: BlobId = serde_json::from_str(&json).unwrap();
             assert_eq!(deserialized, blob_id);
+        }
+
+        #[cfg(feature = "sqlx")]
+        mod sqlx_bounds {
+            use super::BlobId;
+
+            #[test]
+            fn implements_sqlx_traits() {
+                fn assert_type<T: sqlx::Type<sqlx::Sqlite>>() {}
+                fn assert_encode<T: for<'enc> sqlx::Encode<'enc, sqlx::Sqlite>>() {}
+                fn assert_decode<T: for<'dec> sqlx::Decode<'dec, sqlx::Sqlite>>() {}
+                assert_type::<BlobId>();
+                assert_encode::<BlobId>();
+                assert_decode::<BlobId>();
+            }
         }
     }
 }

--- a/src/protocol/threema_id.rs
+++ b/src/protocol/threema_id.rs
@@ -124,6 +124,49 @@ impl FromStr for ThreemaId {
     }
 }
 
+#[cfg(feature = "sqlx")]
+impl<DB> sqlx::Type<DB> for ThreemaId
+where
+    DB: sqlx::Database,
+    String: sqlx::Type<DB>,
+{
+    fn type_info() -> <DB as sqlx::Database>::TypeInfo {
+        <String as sqlx::Type<DB>>::type_info()
+    }
+
+    fn compatible(ty: &<DB as sqlx::Database>::TypeInfo) -> bool {
+        <String as sqlx::Type<DB>>::compatible(ty)
+    }
+}
+
+#[cfg(feature = "sqlx")]
+impl<'enc, DB> sqlx::Encode<'enc, DB> for ThreemaId
+where
+    DB: sqlx::Database,
+    String: sqlx::Encode<'enc, DB>,
+{
+    fn encode_by_ref(
+        &self,
+        buf: &mut <DB as sqlx::Database>::ArgumentBuffer<'enc>,
+    ) -> Result<sqlx::encode::IsNull, sqlx::error::BoxDynError> {
+        <String as sqlx::Encode<'enc, DB>>::encode(self.as_str().to_owned(), buf)
+    }
+}
+
+#[cfg(feature = "sqlx")]
+impl<'dec, DB> sqlx::Decode<'dec, DB> for ThreemaId
+where
+    DB: sqlx::Database,
+    String: sqlx::Decode<'dec, DB>,
+{
+    fn decode(
+        value: <DB as sqlx::Database>::ValueRef<'dec>,
+    ) -> Result<Self, sqlx::error::BoxDynError> {
+        let decoded = <String as sqlx::Decode<'dec, DB>>::decode(value)?;
+        ThreemaId::try_from(decoded.as_str()).map_err(Into::into)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
@@ -237,6 +280,21 @@ mod tests {
         fn from_non_string_fails() {
             let result: Result<ThreemaId, _> = serde_json::from_str("42");
             assert!(result.is_err());
+        }
+    }
+
+    #[cfg(feature = "sqlx")]
+    mod sqlx_bounds {
+        use super::ThreemaId;
+
+        #[test]
+        fn implements_sqlx_traits() {
+            fn assert_type<T: sqlx::Type<sqlx::Sqlite>>() {}
+            fn assert_encode<T: for<'enc> sqlx::Encode<'enc, sqlx::Sqlite>>() {}
+            fn assert_decode<T: for<'dec> sqlx::Decode<'dec, sqlx::Sqlite>>() {}
+            assert_type::<ThreemaId>();
+            assert_encode::<ThreemaId>();
+            assert_decode::<ThreemaId>();
         }
     }
 }


### PR DESCRIPTION
It's useful when a downstream project wants to persist certain information (e.g. public keys or Threema IDs) into a database.